### PR TITLE
Remove dependency of Task on a Reporter

### DIFF
--- a/task/task.go
+++ b/task/task.go
@@ -27,9 +27,9 @@ type Task struct {
 	reporter Reporter
 
 	// Fields below are filled during t.Run()
-	Spans []Span
-	Error error // nil if the task succeeded
-	output []string
+	Spans  []Span
+	Error  error // nil if the task succeeded
+	Output []LogLine
 }
 
 // StringID formats task ID
@@ -78,21 +78,8 @@ func (t *Task) SelfDuration() time.Duration {
 	return d
 }
 
-func (t *Task) StoreLine(line string) {
-	t.output = append(t.output, line)
-}
-
-func (t *Task) OutputTail() string {
-	var ret string
-	start := 0
-	if len(t.output) > 100 {
-		ret = "<truncated, see log>\n"
-		start = len(t.output) - 100
-	}
-	for i := start; i < len(t.output); i++ {
-		ret += t.output[i]
-	}
-	return ret
+func (t *Task) StoreLine(line LogLine) {
+	t.Output = append(t.Output, line)
 }
 
 type contextKey string


### PR DESCRIPTION
consoleReporter used to publish lines back to a Task. This is not sustainable.