### PR TITLE
100 lines is too small for Tectonic's 'go test'

### DIFF
--- a/toplevel/toplevel.go
+++ b/toplevel/toplevel.go
@@ -26,7 +26,7 @@ func formatLine(line task.LogLine) string {
 	return "  | " + line.Line
 }
 
-const maxTailLines = 100
+const maxTailLines = 200
 
 func taskTail(t *task.Task) string {
 	b := strings.Builder{}


### PR DESCRIPTION
This makes it more probable that an error during 'go test' will be printed at
the end of the log