### PR TITLE
Implement uncluttered colored TTY reporter

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,5 @@
 module github.com/ridge/game
 
 go 1.13
+
+require golang.org/x/sys v0.0.0-20210630005230-0f9fa26af87c

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,2 @@
+golang.org/x/sys v0.0.0-20210630005230-0f9fa26af87c h1:F1jZWGFhYfh0Ci55sIpILtKKK8p3i2/krTr0H1rg74I=
+golang.org/x/sys v0.0.0-20210630005230-0f9fa26af87c/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=

--- a/task/registry.go
+++ b/task/registry.go
@@ -35,8 +35,8 @@ type Reporter interface {
 
 // Registry registers runnables for execution
 type Registry struct {
-	reporter Reporter
-	module   string
+	reporters []Reporter
+	module    string
 
 	mu     sync.Mutex
 	tasks  map[interface{}]*Task
@@ -77,9 +77,9 @@ func (r *Registry) Register(fns []interface{}) []*Task {
 
 		if _, exists := r.tasks[identity]; !exists {
 			r.tasks[identity] = &Task{
-				ID:       r.nextID,
-				Runnable: runnable,
-				reporter: r.reporter,
+				ID:        r.nextID,
+				Runnable:  runnable,
+				reporters: r.reporters,
 			}
 			r.nextID++
 		}
@@ -102,9 +102,9 @@ var All = Registry{
 	tasks: map[interface{}]*Task{},
 }
 
-// SetReporter sets the reporter
-func SetReporter(reporter Reporter) {
-	All.reporter = reporter
+// AddReporter adds the reporter
+func AddReporter(reporter Reporter) {
+	All.reporters = append(All.reporters, reporter)
 }
 
 // SetModule sets the code module

--- a/task/streams.go
+++ b/task/streams.go
@@ -6,9 +6,9 @@ import (
 )
 
 type streamLineSink struct {
-	task     *Task
-	reporter Reporter
-	stream   Stream
+	task      *Task
+	reporters []Reporter
+	stream    Stream
 
 	// current non-\n-terminated line of output
 	tailTime time.Time
@@ -18,7 +18,9 @@ type streamLineSink struct {
 func (sls *streamLineSink) storeLine(t time.Time, line string) {
 	logLine := LogLine{Stream: sls.stream, Line: line}
 	sls.task.StoreLine(logLine)
-	sls.reporter.OutputLine(sls.task, t, logLine)
+	for _, r := range sls.reporters {
+		r.OutputLine(sls.task, t, logLine)
+	}
 }
 
 func (sls *streamLineSink) Add(t time.Time, input string) {
@@ -68,9 +70,9 @@ func (slw streamLineWriter) Flush() {
 	slw.sink.Flush(time.Now())
 }
 
-func newStreamLineWriters(task *Task, reporter Reporter) (flushWriter, flushWriter) {
-	stdoutSink := &streamLineSink{task: task, reporter: reporter, stream: StdoutStream}
-	stderrSink := &streamLineSink{task: task, reporter: reporter, stream: StderrStream}
+func newStreamLineWriters(task *Task, reporters []Reporter) (flushWriter, flushWriter) {
+	stdoutSink := &streamLineSink{task: task, reporters: reporters, stream: StdoutStream}
+	stderrSink := &streamLineSink{task: task, reporters: reporters, stream: StderrStream}
 
 	return streamLineWriter{stdoutSink, stderrSink}, streamLineWriter{stderrSink, stdoutSink}
 }

--- a/toplevel/log.go
+++ b/toplevel/log.go
@@ -1,0 +1,62 @@
+package toplevel
+
+import (
+	"fmt"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/ridge/game/task"
+)
+
+func formatLine(line task.LogLine) string {
+	if line.Stream == task.StderrStream {
+		return "E | " + line.Line
+	}
+	return "  | " + line.Line
+}
+
+type fileReporter struct {
+	File *os.File
+}
+
+func (fr fileReporter) Started(t *task.Task) {
+	fmt.Fprintf(fr.File, "%s STARTED %s\n", t.StringID(), t.Name())
+}
+
+func (fr fileReporter) Dependencies(dependent *task.Task, dependees []*task.Task, sequential bool) {
+	s := []string{}
+	for _, d := range dependees {
+		s = append(s, d.String())
+	}
+	op := "DEPS"
+	if sequential {
+		op = "SEQDEPS"
+	}
+	fmt.Fprintf(fr.File, "%s %s %s -> %s\n", dependent.StringID(), op, dependent.Name(), strings.Join(s, ", "))
+}
+
+func (fr fileReporter) Finished(t *task.Task) {
+	tag := "SUCCEEDED"
+	if t.Error != nil {
+		tag = "FAILED"
+		msg := t.Error.Error()
+		if !strings.HasSuffix(msg, "\n") {
+			msg += "\n"
+		}
+		for _, line := range strings.SplitAfter(msg, "\n") {
+			if line == "" {
+				continue
+			}
+			fr.OutputLine(t, t.End(), task.LogLine{Stream: task.StderrStream, Line: line})
+		}
+	}
+	dur := t.Duration()
+	self := t.SelfDuration()
+	fmt.Fprintf(fr.File, "%s %s %s time=%.02fs, self=%.02fs, subtasks=%.02fs\n",
+		t.StringID(), tag, t.Name(), dur.Seconds(), self.Seconds(), (dur - self).Seconds())
+}
+
+func (fr fileReporter) OutputLine(t *task.Task, time time.Time, line task.LogLine) {
+	fmt.Fprintf(fr.File, "%s %s", t.StringID(), formatLine(line))
+}

--- a/toplevel/toplevel.go
+++ b/toplevel/toplevel.go
@@ -345,11 +345,13 @@ Options:
 
 	if logFile, ok := os.LookupEnv("GAMEFILE_LOGFILE"); ok {
 		if err := os.MkdirAll(filepath.Dir(logFile), 0o755); err != nil {
-			panic(err)
+			fmt.Printf("Failed to create directory for log file %s: %v\n", logFile, err)
+			os.Exit(1)
 		}
 		fh, err := os.Create(logFile)
 		if err != nil {
-			panic(err)
+			fmt.Printf("Failed to create log file %s: %v\n", err)
+			os.Exit(1)
 		}
 		defer fh.Close() // Not strictly needed, it's open until the process exits, and it's not buffered
 		task.AddReporter(fileReporter{fh})

--- a/toplevel/toplevel.go
+++ b/toplevel/toplevel.go
@@ -350,7 +350,7 @@ Options:
 		}
 		fh, err := os.Create(logFile)
 		if err != nil {
-			fmt.Printf("Failed to create log file %s: %v\n", err)
+			fmt.Printf("Failed to create log file %s: %v\n", logFile, err)
 			os.Exit(1)
 		}
 		defer fh.Close() // Not strictly needed, it's open until the process exits, and it's not buffered

--- a/toplevel/toplevel.go
+++ b/toplevel/toplevel.go
@@ -17,14 +17,8 @@ import (
 	"time"
 
 	"github.com/ridge/game/task"
+	"github.com/ridge/game/tty"
 )
-
-func formatLine(line task.LogLine) string {
-	if line.Stream == task.StderrStream {
-		return "E | " + line.Line
-	}
-	return "  | " + line.Line
-}
 
 const maxTailLines = 200
 
@@ -40,50 +34,6 @@ func taskTail(t *task.Task) string {
 		b.WriteString(formatLine(t.Output[i]))
 	}
 	return b.String()
-}
-
-type consoleReporter struct {
-}
-
-func (consoleReporter) Started(t *task.Task) {
-	fmt.Printf("%s STARTED %s\n", t.StringID(), t.Name())
-}
-
-func (consoleReporter) Dependencies(dependent *task.Task, dependees []*task.Task, sequential bool) {
-	s := []string{}
-	for _, d := range dependees {
-		s = append(s, d.String())
-	}
-	op := "DEPS"
-	if sequential {
-		op = "SEQDEPS"
-	}
-	fmt.Printf("%s %s %s -> %s\n", dependent.StringID(), op, dependent.Name(), strings.Join(s, ", "))
-}
-
-func (cr consoleReporter) Finished(t *task.Task) {
-	tag := "SUCCEEDED"
-	if t.Error != nil {
-		tag = "FAILED"
-		msg := t.Error.Error()
-		if !strings.HasSuffix(msg, "\n") {
-			msg += "\n"
-		}
-		for _, line := range strings.SplitAfter(msg, "\n") {
-			if line == "" {
-				continue
-			}
-			cr.OutputLine(t, t.End(), task.LogLine{Stream: task.StderrStream, Line: line})
-		}
-	}
-	dur := t.Duration()
-	self := t.SelfDuration()
-	fmt.Printf("%s %s %s time=%.02fs, self=%.02fs, subtasks=%.02fs\n",
-		t.StringID(), tag, t.Name(), dur.Seconds(), self.Seconds(), (dur - self).Seconds())
-}
-
-func (consoleReporter) OutputLine(t *task.Task, time time.Time, line task.LogLine) {
-	fmt.Printf("%s %s", t.StringID(), formatLine(line))
 }
 
 // Target is one build target
@@ -378,7 +328,34 @@ Options:
 	}
 
 	task.SetModule(module)
-	task.SetReporter(consoleReporter{})
+
+	var ttyReporter task.Reporter
+	if _, disableTTY := os.LookupEnv("GAMEFILE_NO_TTY"); !disableTTY {
+		var err error
+		ttyReporter, err = tty.NewReporter()
+		if err == nil {
+			task.AddReporter(ttyReporter)
+		}
+	}
+
+	// Always fall back to non-TTY reporter
+	if ttyReporter == nil {
+		task.AddReporter(fileReporter{os.Stdout})
+	}
+
+	if logFile, ok := os.LookupEnv("GAMEFILE_LOGFILE"); ok {
+		if err := os.MkdirAll(filepath.Dir(logFile), 0o755); err != nil {
+			panic(err)
+		}
+		fh, err := os.Create(logFile)
+		if err != nil {
+			panic(err)
+		}
+		defer fh.Close() // Not strictly needed, it's open until the process exits, and it's not buffered
+		task.AddReporter(fileReporter{fh})
+
+		fmt.Printf("Log file: %s\n", logFile)
+	}
 
 	if len(args) == 0 {
 		if defaultTarget != "" {

--- a/tty/deps.go
+++ b/tty/deps.go
@@ -1,0 +1,32 @@
+package tty
+
+type dep struct {
+	from int
+	to   int
+}
+
+type depSet struct {
+	deps []dep
+}
+
+func (ds *depSet) add(from, to int) {
+	ds.deps = append(ds.deps, dep{from, to})
+}
+
+func (ds *depSet) blocked() map[int]bool {
+	out := map[int]bool{}
+	for _, item := range ds.deps {
+		out[item.from] = true
+	}
+	return out
+}
+
+func (ds *depSet) unblock(to int) {
+	out := []dep{}
+	for _, item := range ds.deps {
+		if item.to != to {
+			out = append(out, item)
+		}
+	}
+	ds.deps = out
+}

--- a/tty/deps.go
+++ b/tty/deps.go
@@ -22,7 +22,7 @@ func (ds *depSet) blocked() map[int]bool {
 }
 
 func (ds *depSet) unblock(to int) {
-	out := []dep{}
+	var out []dep
 	for _, item := range ds.deps {
 		if item.to != to {
 			out = append(out, item)

--- a/tty/reporter_other.go
+++ b/tty/reporter_other.go
@@ -1,0 +1,13 @@
+//go:build !unix
+
+package tty
+
+import (
+	"fmt"
+
+	"github.com/ridge/game/task"
+)
+
+func NewReporter() (task.Reporter, error) {
+	return nil, fmt.Errorf("TTY reporter is only available under Unix")
+}

--- a/tty/reporter_unix.go
+++ b/tty/reporter_unix.go
@@ -1,0 +1,228 @@
+//go:build unix
+
+package tty
+
+import (
+	"fmt"
+	"os"
+	"os/signal"
+	"sort"
+	"strings"
+	"sync"
+	"syscall"
+	"time"
+
+	"github.com/ridge/game/task"
+	"golang.org/x/sys/unix"
+)
+
+// From https://en.wikipedia.org/wiki/ANSI_escape_code#Description
+const (
+	clearToEndOfLine = "\x1b[K"
+	red              = "\x1b[31m"
+	gray             = "\x1b[37m"
+	blue             = "\x1b[34m"
+	defColor         = "\x1b[0m"
+)
+
+type Reporter struct {
+	mu         sync.Mutex
+	termCols   int
+	unfinished map[int]string
+	deps       depSet
+}
+
+// Tasks line format:
+//
+// <gray>... #1234 #4565</gray> <blue>#6666 #7777 #8888 #9999 doing.Stuff</blue>
+//       ^                          ^                     ^
+//       |                          |                     |
+// currently blocked tasks      running tasks     as many task names as fits into the line
+//
+// If the terminal is too narrow to display all unfinished tasks, then
+// first blocked tasks are clipped, then running tasks' names are
+// removed and finally running tasks are clipped.
+
+func (r *Reporter) drawTasksLine() {
+	// Calculate blocked tasks
+	blockedSet := r.deps.blocked()
+
+	var blocked []int
+	for id := range blockedSet {
+		blocked = append(blocked, id)
+	}
+	sort.Ints(blocked)
+
+	// Calculate running tasks
+	var running []int
+	for id := range r.unfinished {
+		if blockedSet[id] {
+			continue
+		}
+		running = append(running, id)
+	}
+	sort.Ints(running)
+
+	// Keep the last column of the terminal free, or the cursor
+	// will jump to the next line and won't be clearable until
+	// this code learns to use cursor navigation commands.
+	maxSize := r.termCols - 1
+
+	runningStr := formatRunningTasks(maxSize, running, r.unfinished)
+	blockedStr := formatBlockedTasks(maxSize-len(runningStr), blocked)
+
+	// Clear the existing tasks line, draw it, move cursor back
+	fmt.Printf("%s%s%s%s%s%s\r", clearToEndOfLine, gray, blockedStr, blue, runningStr, defColor)
+}
+
+func formatRunningTasks(maxSize int, running []int, allTasks map[int]string) string {
+	// Deal with awkward conditions first to avoid doing extra checks below
+	if len(running) == 0 {
+		return ""
+	}
+	if maxSize < 3 {
+		return "..."[:maxSize]
+	}
+
+	// Format all tasks
+	// IDs and texts separate, as we're going to shorten them separately)
+
+	var runningIDs []string
+	var runningTexts []string
+	totalSize := 0
+	for _, id := range running {
+		s := allTasks[id]
+
+		runningID := fmt.Sprintf(" #%04d", id)
+		if len(runningIDs) == 0 {
+			runningID = runningID[1:] // no space before first task
+		}
+		runningIDs = append(runningIDs, runningID)
+		runningTexts = append(runningTexts, " "+s)
+		totalSize += 6 + len(s)
+	}
+
+	// If the total length is larger than the terminal width, remove task names one by one
+	for i := 0; i < len(running) && totalSize > maxSize; i++ {
+		totalSize -= len(runningTexts[i])
+		runningTexts[i] = ""
+	}
+
+	line := ""
+	for i := 0; i < len(runningIDs); i++ {
+		line += runningIDs[i]
+		line += runningTexts[i]
+	}
+
+	// We still can't put all running tasks into the line, then just cut from the beginning
+	if len(line) > maxSize {
+		return "..." + line[len(line)-maxSize+3:]
+	}
+
+	return line
+}
+
+func formatBlockedTasks(maxSize int, blocked []int) string {
+	// Deal with awkward conditions first to avoid doing extra checks below
+	if len(blocked) == 0 {
+		return ""
+	}
+	if maxSize < 3 {
+		return "..."[:maxSize]
+	}
+
+	line := ""
+	for _, id := range blocked {
+		line += fmt.Sprintf("#%04d ", id)
+	}
+
+	// If we can't fit the line, then just cut from the beginning
+	if len(line) > maxSize {
+		return "..." + line[len(line)-maxSize+3:]
+	}
+
+	return line
+}
+
+func (r *Reporter) Started(t *task.Task) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	r.unfinished[t.ID] = t.ShortName()
+
+	r.drawTasksLine()
+}
+
+func (r *Reporter) Dependencies(dependent *task.Task, dependees []*task.Task, sequential bool) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	for _, dependee := range dependees {
+		r.deps.add(dependent.ID, dependee.ID)
+	}
+
+	r.drawTasksLine()
+}
+
+func (r *Reporter) Finished(t *task.Task) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	r.deps.unblock(t.ID)
+	delete(r.unfinished, t.ID)
+
+	r.drawTasksLine()
+}
+
+func formatLine(line task.LogLine) string {
+	if line.Stream == task.StderrStream {
+		return red + strings.TrimRight(line.Line, "\n") + defColor + "\n"
+	}
+	return line.Line
+}
+
+func (r *Reporter) OutputLine(t *task.Task, time time.Time, line task.LogLine) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	// Clear the tasks line before drawing the output
+	fmt.Print(clearToEndOfLine)
+	fmt.Printf("%s %s", t.StringID(), formatLine(line))
+
+	r.drawTasksLine()
+}
+
+func termWidth() (int, error) {
+	ws, err := unix.IoctlGetWinsize(unix.Stdout, unix.TIOCGWINSZ)
+	if err != nil {
+		return -1, err
+	}
+	return int(ws.Col), nil
+}
+
+func NewReporter() (*Reporter, error) {
+	winszCh := make(chan os.Signal, 1)
+	// signal.Notify before TIOCGWINSZ to avoid missing a resize on startup
+	signal.Notify(winszCh, syscall.SIGWINCH)
+
+	cols, err := termWidth()
+	if err != nil {
+		return nil, err
+	}
+	r := &Reporter{
+		termCols:   cols,
+		unfinished: map[int]string{},
+	}
+	go func() {
+		for range winszCh {
+			r.mu.Lock()
+			defer r.mu.Unlock()
+
+			cols, err := termWidth()
+			if err == nil {
+				r.termCols = cols
+			}
+		}
+	}()
+	return r, nil
+}

--- a/tty/reporter_unix.go
+++ b/tty/reporter_unix.go
@@ -192,6 +192,15 @@ func (r *Reporter) OutputLine(t *task.Task, time time.Time, line task.LogLine) {
 	r.drawTasksLine()
 }
 
+func (r *Reporter) handleTermWidthChange() {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	if cols, err := termWidth(); err == nil {
+		r.termCols = cols
+	}
+}
+
 func termWidth() (int, error) {
 	ws, err := unix.IoctlGetWinsize(unix.Stdout, unix.TIOCGWINSZ)
 	if err != nil {
@@ -215,13 +224,7 @@ func NewReporter() (*Reporter, error) {
 	}
 	go func() {
 		for range winszCh {
-			r.mu.Lock()
-			defer r.mu.Unlock()
-
-			cols, err := termWidth()
-			if err == nil {
-				r.termCols = cols
-			}
+			r.handleTermWidthChange()
 		}
 	}()
 	return r, nil


### PR DESCRIPTION
Print currently running/blocked tasks as a status line.

Required addional work outside of the reporter:
- Add GAMEFILE_LOGFILE to save full log to the file
- Add GAMEFILE_NO_TTY to disable TTY reporter
- Implement multiple reporters in core Game code
- Convert consoleReporter to be able to print to file