### PR TITLE
Use "game" tag not only for code search, but also for compilation

### DIFF
--- a/game/main.go
+++ b/game/main.go
@@ -558,7 +558,7 @@ func Compile(goos, goarch, gamePath, goCmd, compileTo string, gofiles []string, 
 		gofiles[i] = filepath.Base(gofiles[i])
 	}
 	debug.Printf("running %s build -o %s %s", goCmd, compileTo, strings.Join(gofiles, " "))
-	c := exec.Command(goCmd, append([]string{"build", "-o", compileTo}, gofiles...)...)
+	c := exec.Command(goCmd, append([]string{"build", "-tags=game", "-o", compileTo}, gofiles...)...)
 	c.Env = environ
 	c.Stderr = stderr
 	c.Stdout = stdout

--- a/game/testdata/mixed_lib_files/subdir/gamefile.go
+++ b/game/testdata/mixed_lib_files/subdir/gamefile.go
@@ -1,4 +1,4 @@
-// +build game
+//go:build !game
 
 package main
 


### PR DESCRIPTION
This allows one to mark packages as "only used in build" and
"not allowed in build".