### PR TITLE
Fix no output if Game is not connected to TTY

### DIFF
--- a/toplevel/toplevel.go
+++ b/toplevel/toplevel.go
@@ -330,17 +330,17 @@ Options:
 
 	task.SetModule(module)
 
-	var ttyReporter task.Reporter
+	var haveReporter bool
 	if _, disableTTY := os.LookupEnv(mg.NoTTYEnv); !disableTTY {
-		var err error
-		ttyReporter, err = tty.NewReporter()
+		ttyReporter, err := tty.NewReporter()
 		if err == nil {
 			task.AddReporter(ttyReporter)
+			haveReporter = true
 		}
 	}
 
 	// Always fall back to non-TTY reporter
-	if ttyReporter == nil {
+	if !haveReporter {
 		task.AddReporter(fileReporter{os.Stdout})
 	}
 


### PR DESCRIPTION
`iface == nil` checks if interface value is nil, not if the value
it holds is nil, so stdout reporter was never added if TTY detection failed.

Related to ridge/tectonic#11387