### PR TITLE
Do not show truncated logs in log output

### DIFF
--- a/toplevel/toplevel.go
+++ b/toplevel/toplevel.go
@@ -24,14 +24,12 @@ import (
 const maxTailLines = 200
 
 func taskTail(t *task.Task) string {
-	b := strings.Builder{}
-
-	start := 0
 	if len(t.Output) > maxTailLines {
-		b.WriteString("<truncated, see logs above>\n")
-		start = len(t.Output) - maxTailLines
+		return "<error is too long, see logs above>\n"
 	}
-	for i := start; i < len(t.Output); i++ {
+
+	b := strings.Builder{}
+	for i := 0; i < len(t.Output); i++ {
 		b.WriteString(formatLine(t.Output[i]))
 	}
 	return b.String()


### PR DESCRIPTION
This was supposed to be a usability feature: if the error from
a task is too long, the last N lines were displayed and Game
pointed user to the full log above. In practice it turned out
that if the task's output is long, then the probability of
issue being printed in the last N lines is low.

So if the log is too long, don't print it at all.